### PR TITLE
Enhance server disconnection user message

### DIFF
--- a/src/view/content.opa
+++ b/src/view/content.opa
@@ -327,6 +327,11 @@ module Content {
      * URN is some if the user is logged in, else none.
      */
     client function init_client(option(URN.t) urn, _) {
+      errTitle = @intl("Connection lost")
+      errBody = <div>{@intl("Please check your network connectivity and then refresh the page")}</div>
+      PingClient.add_connection_lost_handler(function() {
+        Notifications.error(errTitle, errBody)
+      });
       Dom.bind_with_options(
         Dom.select_document(),
         {keypress}, Keyboard.handler,


### PR DESCRIPTION
When the web application can't join the server, an error message is displayed to
the user. This patch uses the Notifications.error helper to display it
